### PR TITLE
Add support for linux, test on ubuntu

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,11 +106,16 @@ jobs:
       run: pod --version | grep "1.9.1"
 
   ubuntu-install:
-    name: install latest version
+    name: install latest on ubuntu
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+
+    - name: setup-ruby
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: '2.6'
 
     - name: setup-cocoapods
       uses: ./

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,3 +104,18 @@ jobs:
 
     - name: Validate version
       run: pod --version | grep "1.9.1"
+
+  ubuntu-install:
+    name: install latest version
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: setup-cocoapods
+      uses: ./
+      with:
+        version: latest
+
+    - name: Validate version
+      run: pod --version

--- a/dist/index.js
+++ b/dist/index.js
@@ -1573,8 +1573,8 @@ const core = __importStar(__webpack_require__(470));
 const installer_1 = __webpack_require__(749);
 const run = async () => {
     try {
-        if (process.platform !== "darwin") {
-            throw new Error(`This task is intended only for macOS platform. It can't be run on '${process.platform}' platform`);
+        if (process.platform !== "darwin" && process.platform !== "linux") {
+            throw new Error(`This task is intended for macOS and linux platforms. It can't be run on '${process.platform}' platform`);
         }
         let versionSpec = core.getInput("version", { required: false });
         const podfilePath = core.getInput("podfile-path", { required: false });

--- a/src/setup-cocoapods.ts
+++ b/src/setup-cocoapods.ts
@@ -3,8 +3,8 @@ import { CocoapodsInstaller } from "./installer";
 
 const run = async (): Promise<void> => {
     try {
-        if (process.platform !== "darwin") {
-            throw new Error(`This task is intended only for macOS platform. It can't be run on '${process.platform}' platform`);
+        if (process.platform !== "darwin" && process.platform !== "linux") {
+            throw new Error(`This task is intended for macOS and linux platforms. It can't be run on '${process.platform}' platform`);
         }
 
         let versionSpec = core.getInput("version", { required: false });


### PR DESCRIPTION
Fixes #3 

Allow running on linux, and add a CI test for use on ubuntu-latest 

NB: On linux, it's important to ensure a compatible ruby version. This is easily taken care of with a `setup-ruby` step.