### PR TITLE
Bump Node.js version in workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
       uses: actions/checkout@v2
     
     - name: Remove pre-installed version
-      run: gem uninstall cocoapods --all --executables
+      run: gem uninstall cocoapods --all --executables --ignore-dependencies
 
     - name: setup-cocoapods
       uses: ./
@@ -50,7 +50,7 @@ jobs:
       uses: actions/checkout@v2
     
     - name: Remove pre-installed version
-      run: gem uninstall cocoapods --all --executables
+      run: gem uninstall cocoapods --all --executables --ignore-dependencies
 
     - name: Install needed version
       run: gem install cocoapods -v 1.9.1

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set Node.JS
       uses: actions/setup-node@master
       with:
-        node-version: 12.x
+        node-version: 16.x
 
     - name: npm install
       run: npm install

--- a/__tests__/installer.test.ts
+++ b/__tests__/installer.test.ts
@@ -19,7 +19,7 @@ describe("CocoapodsInstaller", () => {
         it("replace existing version", async () => {
             CocoapodsInstaller["getInstalledVersion"] = jest.fn().mockReturnValue("1.8.5");
             await CocoapodsInstaller.install("1.9.1");
-            expect(execCommandSpy).toHaveBeenCalledWith("gem", ["uninstall", "cocoapods", expect.any(String), expect.any(String)]);
+            expect(execCommandSpy).toHaveBeenCalledWith("gem", ["uninstall", "cocoapods", expect.any(String), expect.any(String), expect.any(String)]);
             expect(execCommandSpy).toHaveBeenCalledWith("gem", ["install", "cocoapods", expect.any(String), expect.any(String), expect.any(String)]);
         });
 

--- a/__tests__/podfile-parser.test.ts
+++ b/__tests__/podfile-parser.test.ts
@@ -6,15 +6,15 @@ describe("getVersionFromPodfile", () => {
         ["Podfile.lock", "1.5.3"],
         ["Podfile2.lock", "1.9.3"],
         ["Podfile3.lock", "1.10.0.rc.1"],
-        ["Podfile4.lock", "1.9.0.beta.2"],
-        ["Podfile5.lock", null]
+        ["Podfile4.lock", "1.9.0.beta.2"]
     ])("test case %#", (input: string, expected: string | null) => {
         const testCasePath = path.resolve(path.join(__dirname, "podfile-example", input));
-        if (expected) {
-            expect(getVersionFromPodfile(testCasePath)).toBe(expected);
-        } else {
-            expect(() => getVersionFromPodfile(testCasePath)).toThrow();
-        }
+        expect(getVersionFromPodfile(testCasePath)).toBe(expected);
+    });
+
+    it("fails on invalid podfile", () => {
+        const testCasePath = path.resolve(path.join(__dirname, "podfile-example", "Podfile5.lock"));
+        expect(() => getVersionFromPodfile(testCasePath)).toThrow();
     });
 });
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -42,7 +42,7 @@ class CocoapodsInstaller {
             return;
         }
         // Remove pre-installed version of Cocoapods
-        exec.exec("gem", ["uninstall", "cocoapods", "--all", "--executables"]);
+        exec.exec("gem", ["uninstall", "cocoapods", "--all", "--executables", "--ignore-dependencies"]);
         // Install new version of Cocoapods
         const versionArguments = (versionSpec === "latest") ? [] : ["-v", versionSpec];
         await exec.exec("gem", ["install", "cocoapods", ...versionArguments, "--no-document"]);

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -12,7 +12,7 @@ export class CocoapodsInstaller {
         }
 
         // Remove pre-installed version of Cocoapods
-        exec.exec("gem", ["uninstall", "cocoapods", "--all", "--executables"]);
+        exec.exec("gem", ["uninstall", "cocoapods", "--all", "--executables", "--ignore-dependencies"]);
 
         // Install new version of Cocoapods
         const versionArguments = (versionSpec === "latest") ? [] : ["-v", versionSpec];


### PR DESCRIPTION
Included changes:
- Use `--ignore-dependencies` param for uninstall command. Otherwise, it fails on Hosted macOS Runners
- Bump Node.js version in workflow from 12 to 16
- Fix a couple of linter problems